### PR TITLE
bugfix: file list page infinite loop

### DIFF
--- a/api.go
+++ b/api.go
@@ -168,7 +168,7 @@ func (c *PikPakClient) FileList(limit int, parentId string, nextPageToken string
 		ThumbnailSize: ThumbnailSizeM,
 		Limit:         strconv.Itoa(limit),
 		WithAudit:     strconv.FormatBool(true),
-		NextPageToken: nextPageToken,
+		PageToken:     nextPageToken,
 		Filters:       string(filtersBz),
 	}
 	bz, err := json.Marshal(&req)

--- a/api_test.go
+++ b/api_test.go
@@ -2,12 +2,21 @@ package pikpakgo_test
 
 import (
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
 	pikpakgo "github.com/lyqingye/pikpak-go"
 
 	"github.com/stretchr/testify/suite"
+)
+
+var (
+	username = os.Getenv("PIKPAK_USERNAME")
+	password = os.Getenv("PIKPAK_PASSWORD")
+
+	// getAllFileFieldId: Make sure your field contains 100+ files. leave this env empty to skip get all files test.
+	getAllFileFieldId = os.Getenv("PIKPAK_ALL_FILE_FIELD_ID")
 )
 
 type TestPikpakSuite struct {
@@ -20,7 +29,7 @@ func TestPikpakAPI(t *testing.T) {
 }
 
 func (suite *TestPikpakSuite) SetupTest() {
-	client, err := pikpakgo.NewPikPakClient("", "")
+	client, err := pikpakgo.NewPikPakClient(username, password)
 	suite.NoError(err)
 	err = client.Login()
 	suite.NoError(err)
@@ -209,4 +218,15 @@ func (suite *TestPikpakSuite) TestDeleteAllFiles() {
 	suite.NoError(err)
 	err = suite.client.EmptyTrash()
 	suite.NoError(err)
+}
+
+func (suite *TestPikpakSuite) TestGetAllFiles() {
+	if getAllFileFieldId == "" {
+		return
+	}
+	files, err := suite.client.FileListAll(getAllFileFieldId)
+	suite.NoError(err)
+	suite.NotEmpty(files)
+	// Make sure your field contains 100+ files
+	suite.Greater(len(files), 100)
 }

--- a/types.go
+++ b/types.go
@@ -509,7 +509,7 @@ type RequestFileList struct {
 	ThumbnailSize string `json:"thumbnail_size,omitempty"`
 	Limit         string `json:"limit,omitempty"`
 	WithAudit     string `json:"with_audit,omitempty"`
-	NextPageToken string `json:"next_page_token,omitempty"`
+	PageToken     string `json:"page_token,omitempty"`
 	Filters       string `json:"filters,omitempty"`
 }
 


### PR DESCRIPTION
FileList request paramater is `page_token`, not `next_page_token`.
send request with `next_page_token` will cause `FileListAll` infinite loop, PikPak assume page_token is empty, will send first page' data. and `len(ls.Files) < pageSize || ls.NextPageToken == ""` will never break.
ps: this problem only reproduced when target field(directory)'s file count bigger than 100.
<img width="953" alt="image" src="https://github.com/lyqingye/pikpak-go/assets/20899726/bc76e563-d377-4877-af4d-8a2f35b05772">
